### PR TITLE
Task 1 - Implement a minimal version to download and parse the metadata files (redhat's Primary-xml file)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 metadata/
 db
+__pycache__/

--- a/implementation_1.py
+++ b/implementation_1.py
@@ -33,7 +33,6 @@ EMPTY_URL_ERROR = "ERROR: URL should not be empty."
 FILENAME_ERROR = "ERROR: Filename should not be empty."
 UNKNOWN_FORMAT = "ERROR: Unknown file format. Can't extract."
 
-
 # ARCHIVE EXTENSIONS
 ZIP_EXTENSION = ".zip"
 TAR_EXTENSION = ".tar"
@@ -82,6 +81,7 @@ def download_primary_xml_v2(url: str, primary_xml: str):
 def parse_primary_xml(file_path):
     handler = PrimaryXmlHandler()
     parser = xml.sax.make_parser()
+    # parser.setFeature(xml.sax.handler.feature_namespaces, True)  # TODO Fix problem (probably for the root tag)
     parser.setContentHandler(handler)
 
     try:

--- a/implementation_1.py
+++ b/implementation_1.py
@@ -1,0 +1,75 @@
+"""
+This is a minimal implementation of the lazy reposync parser.
+It downloads the target repository's metadata file(s) from the
+given url and parses it(them)
+"""
+
+# TODO Check for the signature
+# TODO Use SAX parser
+# TODO Define the best chunk size (consider calculating the current os's free memory and the file size and extract a formula)
+# TODO Evaluate the two versions of the download/ benchmark them/ write some tests about them
+# TODO After finishing, complete for all other files, normalize the sql code
+
+import argparse
+import requests
+import os
+import shutil
+from urllib.parse import urljoin
+
+CACHE_DIR = './cache/metadata/'  # TODO change it into /var/cache/...
+PRIMARY_XML = '00c99a7e67dac325f1cbeeedddea3e4001a8f803c9bf43d9f50b5f1c756b0887-primary.xml.gz' # TODO can the name of this file change ?
+
+def create_args_parser():
+    args_parser = argparse.ArgumentParser(description='Lazy reposync service')
+    args_parser.add_argument('--url', '-u', help='The target url of the remote repository of which we\'ll '
+                                                 'parse the metadata')
+    return args_parser
+
+
+def download_primary_xml_v1(url: str, primary_xml: str):
+    """Download the primary-xml file from the given repository url"""
+    try:
+        primary_xml_url = urljoin(url, primary_xml)
+        with requests.get(primary_xml_url, stream=True) as response:
+            response.raise_for_status()  # check for status code
+            with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+                print(f"file {primary_xml} was downloaded successfully!")
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading {primary_xml} file:", e)
+
+
+def download_primary_xml_v2(url: str, primary_xml: str):
+    """Download the primary-xml file from the given repository url"""
+    try:
+        primary_xml_url = urljoin(url, primary_xml)
+        response = requests.get(primary_xml_url, stream=True)
+        with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as out_file:
+            shutil.copyfileobj(response.raw, out_file)
+        print(f"file {primary_xml} was downloaded successfully!")
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading {primary_xml} file:", e)
+
+
+
+
+def parse_primary_xml():
+    pass
+
+
+def download_and_parse_metadata(program_args):
+    if not program_args.url:
+        print('Error: target url not defined!')
+        raise ValueError('Target url was not provided.')
+
+    repo_url = program_args.url
+    # print(repo_url, end='')
+    download_primary_xml_v1(repo_url, PRIMARY_XML)
+    parse_primary_xml()
+
+
+if __name__ == '__main__':
+    parser = create_args_parser()
+    args = parser.parse_args()
+    download_and_parse_metadata(args)

--- a/implementation_1.py
+++ b/implementation_1.py
@@ -9,15 +9,38 @@ given url and parses it(them)
 # TODO Define the best chunk size (consider calculating the current os's free memory and the file size and extract a formula)
 # TODO Evaluate the two versions of the download/ benchmark them/ write some tests about them
 # TODO After finishing, complete for all other files, normalize the sql code
+# TODO Should we parse the files at the time of download, or in a second step ?
 
 import argparse
+import xml.sax
+
 import requests
 import os
 import shutil
 from urllib.parse import urljoin
+import zipfile
+import tarfile
+import gzip
+
+from memory_profiler import profile
+
+from metadata_parser import PrimaryXmlHandler
 
 CACHE_DIR = './cache/metadata/'  # TODO change it into /var/cache/...
-PRIMARY_XML = '00c99a7e67dac325f1cbeeedddea3e4001a8f803c9bf43d9f50b5f1c756b0887-primary.xml.gz' # TODO can the name of this file change ?
+PRIMARY_XML = '00c99a7e67dac325f1cbeeedddea3e4001a8f803c9bf43d9f50b5f1c756b0887-primary.xml.gz'  # TODO can the name of this file change ?
+
+EMPTY_URL_ERROR = "ERROR: URL should not be empty."
+FILENAME_ERROR = "ERROR: Filename should not be empty."
+UNKNOWN_FORMAT = "ERROR: Unknown file format. Can't extract."
+
+
+# ARCHIVE EXTENSIONS
+ZIP_EXTENSION = ".zip"
+TAR_EXTENSION = ".tar"
+TAR_GZ_EXTENSION = ".tar.gz"
+TGZ_EXTENSION = ".tgz"
+GZ_EXTENSION = ".gz"
+
 
 def create_args_parser():
     args_parser = argparse.ArgumentParser(description='Lazy reposync service')
@@ -34,12 +57,14 @@ def download_primary_xml_v1(url: str, primary_xml: str):
             response.raise_for_status()  # check for status code
             with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as f:
                 for chunk in response.iter_content(chunk_size=8192):
+                    # chunk_size to be efficiently determined
                     f.write(chunk)
                 print(f"file {primary_xml} was downloaded successfully!")
     except requests.exceptions.RequestException as e:
         print(f"Error downloading {primary_xml} file:", e)
 
 
+@profile
 def download_primary_xml_v2(url: str, primary_xml: str):
     """Download the primary-xml file from the given repository url"""
     try:
@@ -48,25 +73,77 @@ def download_primary_xml_v2(url: str, primary_xml: str):
         with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as out_file:
             shutil.copyfileobj(response.raw, out_file)
         print(f"file {primary_xml} was downloaded successfully!")
+        response.close()
     except requests.exceptions.RequestException as e:
         print(f"Error downloading {primary_xml} file:", e)
 
 
+@profile
+def parse_primary_xml(file_path):
+    handler = PrimaryXmlHandler()
+    parser = xml.sax.make_parser()
+    parser.setContentHandler(handler)
+
+    try:
+        parser.parse(file_path)
+    except Exception as e:
+        print("Error parsing file: ", e)
 
 
-def parse_primary_xml():
-    pass
+def get_filename(url):
+    """Extract filename from file url"""
+    filename = os.path.basename(url)
+    return filename
 
 
+def get_file_location(target_path, filename):
+    """ Concatenate download directory and filename"""
+    return target_path + filename
+
+
+def extract_file(target_path, filename):
+    """Extract file based on file extension target_path: string, location where data will be extracted filename:
+    string, name of the file along with extension"""
+    if filename == "" or filename is None:
+        raise Exception(FILENAME_ERROR)
+
+    file_location = get_file_location(target_path, filename)
+
+    if filename.endswith(ZIP_EXTENSION):
+        print(f"Extracting {file_location} file")
+        zipf = zipfile.ZipFile(file_location, 'r')
+        zipf.extractall(target_path)
+        zipf.close()
+    elif filename.endswith(TAR_EXTENSION) or \
+            filename.endswith(TAR_GZ_EXTENSION) or \
+            filename.endswith(TGZ_EXTENSION):
+        print(f"Extracting {file_location} file")
+        tarf = tarfile.open(file_location, 'r')
+        tarf.extractall(target_path)
+        tarf.close()
+    elif filename.endswith(GZ_EXTENSION):
+        print(f"Extracting {file_location} file")
+        out_file = file_location[:-3]
+        with gzip.open(file_location, "rt") as f_in:
+            with open(out_file, "w") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+    else:
+        raise ValueError(f"Unknown file format: {UNKNOWN_FORMAT}")
+    os.remove(file_location)
+    print(f"Removing file: {file_location}")
+
+
+@profile
 def download_and_parse_metadata(program_args):
     if not program_args.url:
         print('Error: target url not defined!')
-        raise ValueError('Target url was not provided.')
+        raise ValueError('Target url was not provided. Please run python prog -u https://your-repository-url.com')
 
     repo_url = program_args.url
     # print(repo_url, end='')
-    download_primary_xml_v1(repo_url, PRIMARY_XML)
-    parse_primary_xml()
+    download_primary_xml_v2(repo_url, PRIMARY_XML)
+    extract_file(CACHE_DIR, PRIMARY_XML)
+    parse_primary_xml(os.path.join(CACHE_DIR, PRIMARY_XML.rstrip(".gz")))
 
 
 if __name__ == '__main__':

--- a/metadata_parser.py
+++ b/metadata_parser.py
@@ -1,0 +1,47 @@
+import xml.sax
+import re
+
+
+class PrimaryXmlHandler(xml.sax.ContentHandler):
+
+    def __init__(self):
+        self.current = ""  # current tag
+        self.currentParentTreeStack = []  # useful for nested tags
+        # self.count = 0  # only for testing, to limit the output
+
+    def startElement(self, name, attrs):
+        if name == "metadata":
+            return  # We can remove the tag from the file (or a copy of it) prior processing to avoid making this test
+        self.current = name
+        self.currentParentTreeStack.append(name)
+        #self.count += 1
+        #print(60 * "-")
+        print(f"current: [{self.current}] | attrs: { {attr: attrs[attr] for attr in attrs.getNames()} }")
+        print(f"Tag tree: {'/'.join(self.currentParentTreeStack)}")
+        print(60 * "-")
+
+    def startElementNS(self, name, qname, attrs):
+        self.current = qname  # TODO should we keep the namespace prefix ('rpm' for eg) or just
+        self.currentParentTreeStack.append(qname)
+        #print(60 * "-")
+        print(f"current: [{self.current}] | attrs: { {attr: attrs[attr] for attr in attrs.getNames()} }")
+        print(f"Tag tree: {'/'.join(self.currentParentTreeStack)}")
+
+    def characters(self, content):
+        if re.match('^[\w-]+$', content) is not None:  # alpha-num and dashes '-'
+            print(f"current: [{self.current}]")
+            print(f"Value: {content.strip()}")
+
+    def endElement(self, name):
+        # print(f"--End {self.current}")
+        # if self.count == 100:
+        #     exit(0)
+        self.currentParentTreeStack.pop()
+        print(60 * "-")
+
+    def endElementNS(self, name, qname):
+        self.currentParentTreeStack.pop()
+        print(60 * "-")
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,17 @@
 certifi==2024.2.2
 charset-normalizer==3.3.2
+exceptiongroup==1.2.1
 greenlet==3.0.3
 idna==3.6
+iniconfig==2.0.0
+memory-profiler==0.61.0
+packaging==24.0
+pluggy==1.5.0
+psutil==5.9.8
 psycopg2-binary==2.9.9
+pytest==8.2.1
 requests==2.31.0
 SQLAlchemy==2.0.28
+tomli==2.0.1
 typing_extensions==4.10.0
 urllib3==2.2.1

--- a/test_implementation_1.py
+++ b/test_implementation_1.py
@@ -1,0 +1,18 @@
+import pytest
+from implementation_1 import create_args_parser, download_and_parse_metadata
+
+
+def test_no_arguments():
+    parser = create_args_parser()
+    with pytest.raises(ValueError, match="Target url was not provided."):
+        args = parser.parse_args([])
+        download_and_parse_metadata(args)
+
+
+@pytest.mark.skip
+def test_url_argument(capsys):
+    parser = create_args_parser()
+    args = parser.parse_args(['-u', 'https://download.opensuse.org/update/leap/15.5/oss/repodata/'])
+    download_and_parse_metadata(args)
+    captured = capsys.readouterr()
+    assert captured.out == 'https://download.opensuse.org/update/leap/15.5/oss/repodata/'


### PR DESCRIPTION
## Description
@cbosdo @agraul
In this PR, we've made a minimal implementation of the process of downloading and parsing a package's metadata file (Primary-xml in our case).
## 1. File download
In order to make the download more memory efficient, we used **streams** to download and process the data in chunks. We also used **two different approaches to copy the content of each chunk into the target file**:
### 1.1 Default: writing directly to the file
```python
with requests.get(primary_xml_url, stream=True) as response:
            response.raise_for_status()  # check for status code
            with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as f:
                for chunk in response.iter_content(chunk_size=8192):
                    # chunk_size to be efficiently determined
                    f.write(chunk)
                print(f"file {primary_xml} was downloaded successfully!")
```
### 1.2 Using shutil.copyfileobj
```python
    try:
        primary_xml_url = urljoin(url, primary_xml)
        response = requests.get(primary_xml_url, stream=True)
        with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as out_file:
            shutil.copyfileobj(response.raw, out_file)
        print(f"file {primary_xml} was downloaded successfully!")
        response.close()
    except requests.exceptions.RequestException as e:
        print(f"Error downloading {primary_xml} file:", e)
```
For more information about shutil, please [shutil.copyfileobj](https://docs.python.org/3/library/shutil.html#shutil.copyfileobj)
## 2. File Parse (using SAX)
After downloading and extracting the Primary-xml gz file, we now have to parse it. To do it efficiently we used **SAX** instead of **DOM**, because it requires significantly less memory to process an XML document than the DOM.

Currently, the only thing we're doing is that we print, for each tag, its `name`, its `attributes`, its `Tag tree` (this is a variable that we defined and it can be useful to identify nested tags, and it will make it easier to give context to each tag), and its `value` if it has one.
Here's an example of the output:

```bash
current: [package] | attrs: {'type': 'rpm'}
Tag tree: package
------------------------------------------------------------
current: [name] | attrs: {}
Tag tree: package/name
------------------------------------------------------------
current: [name]
Value: gstreamer-plugins-bad
------------------------------------------------------------
...
------------------------------------------------------------
current: [rpm:entry] | attrs: {'name': 'gst-plugins-bad', 'flags': 'EQ', 'epoch': '0', 'ver': '1.22.0'}
Tag tree: package/format/rpm:provides/rpm:entry
------------------------------------------------------------
current: [rpm:entry] | attrs: {'name': 'gstreamer-plugins-bad', 'flags': 'EQ', 'epoch': '0', 'ver': '1.22.0', 'rel': 'lp155.3.4.1'}
Tag tree: package/format/rpm:provides/rpm:entry
```
## Benchmark
### Memory
We used a python library called `memory-profiler`, so we can have good idea on how much memory the download and the parsing are using. This is by decorating the method we want to benchmark with `@profile`.

In our case, we've decorated: 
```python 
@profile
def download_primary_xml_v2(url: str, primary_xml: str):
```
and
```python
@profile
def parse_primary_xml(file_path)
```
in order to visualize the used memory for both the download and the parse.
### Time
For the execution time, we used the linux `time` command on our program to have and idea about the total execution time. 

We might want to write a shell script that executes the program several times and return the average execution time. And clearing the memory cache after each iteration.
## Run
We've tested the program on the `https://download.opensuse.org/update/leap/15.5/oss/repodata/` repository, and more specifically on the `00c99a7e67dac325f1cbeeedddea3e4001a8f803c9bf43d9f50b5f1c756b0887-primary.xml.gz` file inside of it.

Here's the final run command:
```bash
time python3 -m memory_profiler implementation_1.py -u https://download.opensuse.org/update/leap/15.5/oss/repodata/
```
And here's the output:
```bash
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    66     25.8 MiB     25.8 MiB           1   @profile
    67                                         def download_primary_xml_v2(url: str, primary_xml: str):
    68                                             """Download the primary-xml file from the given repository url"""
    69     25.8 MiB      0.0 MiB           1       try:
    70     25.8 MiB      0.0 MiB           1           primary_xml_url = urljoin(url, primary_xml)
    71     29.0 MiB      3.2 MiB           1           response = requests.get(primary_xml_url, stream=True)
    72     29.0 MiB      0.0 MiB           1           with open(os.path.join(CACHE_DIR, primary_xml), 'wb') as out_file:
    73     29.1 MiB      0.1 MiB           1               shutil.copyfileobj(response.raw, out_file)
    74     29.1 MiB      0.0 MiB           1           print(f"file {primary_xml} was downloaded successfully!")
    75     29.1 MiB      0.0 MiB           1           response.close()
    76                                             except requests.exceptions.RequestException as e:
    77                                                 print(f"Error downloading {primary_xml} file:", e)

...
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    80     29.4 MiB     29.4 MiB           1   @profile
    81                                         def parse_primary_xml(file_path):
    82     29.4 MiB      0.0 MiB           1       handler = PrimaryXmlHandler()
    83     29.6 MiB      0.2 MiB           1       parser = xml.sax.make_parser()
    84                                             # parser.setFeature(xml.sax.handler.feature_namespaces, True)  # TODO Fix problem (probably for the root tag)
    85     29.6 MiB      0.0 MiB           1       parser.setContentHandler(handler)
    86                                         
    87     29.6 MiB      0.0 MiB           1       try:
    88     29.6 MiB      0.0 MiB           1           parser.parse(file_path)
    89     29.6 MiB      0.0 MiB           1       except Exception as e:
    90     29.6 MiB      0.0 MiB           1           print("Error parsing file: ", e)
...
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   136     25.8 MiB     25.8 MiB           1   @profile
   137                                         def download_and_parse_metadata(program_args):
   138     25.8 MiB      0.0 MiB           1       if not program_args.url:
   139                                                 print('Error: target url not defined!')
   140                                                 raise ValueError('Target url was not provided. Please run python prog -u https://your-repository-url.com')
   141                                         
   142     25.8 MiB      0.0 MiB           1       repo_url = program_args.url
   143                                             # print(repo_url, end='')
   144     29.1 MiB      3.4 MiB           1       download_primary_xml_v2(repo_url, PRIMARY_XML)
   145     29.4 MiB      0.2 MiB           1       extract_file(CACHE_DIR, PRIMARY_XML)
   146     29.6 MiB      0.2 MiB           1       parse_primary_xml(os.path.join(CACHE_DIR, PRIMARY_XML.rstrip(".gz")))
...
real    0m4.559s
user    0m2.240s
sys     0m0.054s
```

## TODO
- **chunk_size**: I think we should determine the best `chunk_size` for each processed file. Maybe we can make a formula that consider the **file size** and the current **free memory** on the system.
- **Signature**: we're still not checking for the signature after the download, so we should do that.
- **// Processing**: is it worth, and possible, to use parallel processing at this stage ?
- **namespace mode**: Currently the namespace mode is not active; this means that the `def startElementNS(..)` and `def endElementNS(..)` are not working. We can activate them using `parser.setFeature(xml.sax.handler.feature_namespaces, True)`, but we still have a minor parsing issue (probably related to the root element).

## Questions
How to interpret the content of the `Primary-xml` file and decide how to organize its content, for eg:
```xml
...
<format>
    <rpm:license>LGPL-2.1-or-later</rpm:license>
    <rpm:vendor>openSUSE</rpm:vendor>
    <rpm:group>Productivity/Multimedia/Other</rpm:group>
    <rpm:buildhost>armbuild26</rpm:buildhost>
    <rpm:sourcerpm>gstreamer-plugins-bad-1.22.0-lp155.3.4.1.src.rpm</rpm:sourcerpm>
    <rpm:header-range start="6200" end="149568"/>
    <rpm:provides>
      <rpm:entry name="gst-plugins-bad" flags="EQ" epoch="0" ver="1.22.0"/>
      <rpm:entry name="gstreamer-plugins-bad" flags="EQ" epoch="0" ver="1.22.0" rel="lp155.3.4.1"/>
      <rpm:entry name="gstreamer-plugins-bad(aarch-64)" flags="EQ" epoch="0" ver="1.22.0" rel="lp155.3.4.1"/>
      <rpm:entry name="gstreamer1(decoder-application/dash+xml)()(64bit)"/>
      <rpm:entry name="gstreamer1(decoder-application/mxf)()(64bit)"/>
...
```
what does each entry represent? and are they all subject to be saved into the db later ? 